### PR TITLE
Fixing a few things where there is ambiguous import of `diesel` identifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub fn asjsonb_macro_derive(input: TokenStream) -> TokenStream {
 
     let gen = quote! {
         mod #scope {
+            use super::#name;
             use std::io::Write;
             use ::diesel::{AsExpression, FromSqlRow};
             use ::diesel::sql_types::Jsonb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ pub fn asjsonb_macro_derive(input: TokenStream) -> TokenStream {
 
     let gen = quote! {
         mod #scope {
-            use super::*;
             use std::io::Write;
             use ::diesel::{AsExpression, FromSqlRow};
             use ::diesel::sql_types::Jsonb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,11 @@ pub fn asjsonb_macro_derive(input: TokenStream) -> TokenStream {
         mod #scope {
             use super::*;
             use std::io::Write;
-            use diesel::{AsExpression, FromSqlRow};
-            use diesel::sql_types::Jsonb;
-            use diesel::pg::{Pg, PgValue};
-            use diesel::serialize::{self, IsNull, Output, ToSql};
-            use diesel::deserialize::{self, FromSql};
+            use ::diesel::{AsExpression, FromSqlRow};
+            use ::diesel::sql_types::Jsonb;
+            use ::diesel::pg::{Pg, PgValue};
+            use ::diesel::serialize::{self, IsNull, Output, ToSql};
+            use ::diesel::deserialize::{self, FromSql};
 
             #[derive(FromSqlRow, AsExpression)]
             #[diesel(foreign_derive)]


### PR DESCRIPTION
I'm using `rocket_db_pools` `diesel_async` and a common use of this combo is to do `use rocket_db_pools::diesel;` which is a re-export of `diesel` with prelude types overridden with async variants from `diesel_async`.

This proc-macro gets VERY confused by this.  This PR fixes this:

1. Refer directly to the `diesel` crate using `::diesel` (as opposed to previous referring to whatever `diesel` referred to in local scope. )
2. Only import `super::#name` instead of `super::*`