### PR TITLE
removes extra `]` from the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```rust
-#[derive(AsJsonb)]]
+#[derive(AsJsonb)]
 struct Something {
     thing: String,
 }


### PR DESCRIPTION
There's a tiny typo in the README file. 

This is to correct it